### PR TITLE
feat: add filtering and log priority functionality to Android native logs

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNNativeLogsModule.java
+++ b/android/src/main/java/com/reactlibrary/RNNativeLogsModule.java
@@ -10,6 +10,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableNativeArray;
 
@@ -29,37 +30,52 @@ public class RNNativeLogsModule extends ReactContextBaseJavaModule {
     private File getFile(String fileIdentifier) {
         File path = this.reactContext.getFilesDir();
         String pathname = path + "/" + fileIdentifier + ".txt";
-        File file = new File(pathname);
-        return file;
+        return new File(pathname);
     }
 
     @ReactMethod
-    public void setUpRedirectLogs(String fileIdentifier, final Promise promise) {
+    public void setUpRedirectLogs(String fileIdentifier, String logLevel, final Promise promise) {
         try {
             File file = getFile(fileIdentifier);
             file.createNewFile();
             int pid = android.os.Process.myPid();
-            Runtime.getRuntime().exec("logcat -v time -f " + file + " --pid=" + pid);
+            StringBuilder commandBuilder = new StringBuilder();
+            commandBuilder.append("logcat -v time -f ").append(file.getAbsolutePath()).append(" --pid=").append(pid);
+
+            if (logLevel != null) {
+                String packagePrefix = reactContext.getPackageName() + ":";
+                commandBuilder.append(" *:").append(logLevel).append(" ").append(packagePrefix).append(logLevel);
+            }
+
+            String command = commandBuilder.toString();
+            Runtime.getRuntime().exec(command);
             promise.resolve(true);
         } catch (IOException e) {
             promise.reject("Error when redirecting logs", String.valueOf(e));
         }
     }
 
+    private boolean isIgnoredTag(String line, ReadableArray tags) {
+        for (int i = 0; i < tags.size(); i++) {
+            String tag = tags.getString(i);
+            if (line.contains(tag)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @ReactMethod
-    public void readOutputLogs(String fileIdentifier, final Promise promise) {
+    public void readOutputLogs(String fileIdentifier, ReadableArray tags, final Promise promise) {
         try {
             File file = getFile(fileIdentifier);
             WritableArray writableArray = new WritableNativeArray();
             FileReader fileReader = new FileReader(file);
             BufferedReader br = new BufferedReader(fileReader);
-            boolean done = false;
 
-            while (!done) {
-                final String line = br.readLine();
-                done = (line == null);
-
-                if (line != null) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (!isIgnoredTag(line, tags)) {
                     writableArray.pushString(line);
                 }
             }

--- a/android/src/main/java/com/reactlibrary/RNNativeLogsModule.java
+++ b/android/src/main/java/com/reactlibrary/RNNativeLogsModule.java
@@ -55,6 +55,11 @@ public class RNNativeLogsModule extends ReactContextBaseJavaModule {
         }
     }
 
+    @ReactMethod
+    public void setUpRedirectLogs(String fileIdentifier, final Promise promise) {
+        setUpRedirectLogs(fileIdentifier, null, promise);
+    }
+
     private boolean isIgnoredTag(String line, ReadableArray tags) {
         for (int i = 0; i < tags.size(); i++) {
             String tag = tags.getString(i);
@@ -75,7 +80,7 @@ public class RNNativeLogsModule extends ReactContextBaseJavaModule {
 
             String line;
             while ((line = br.readLine()) != null) {
-                if (!isIgnoredTag(line, tags)) {
+                if (tags == null || !isIgnoredTag(line, tags)) {
                     writableArray.pushString(line);
                 }
             }
@@ -86,5 +91,10 @@ public class RNNativeLogsModule extends ReactContextBaseJavaModule {
         } catch (IOException e) {
             promise.reject("Error when reading logs", String.valueOf(e));
         }
+    }
+
+    @ReactMethod
+    public void readOutputLogs(String fileIdentifier, final Promise promise) {
+        readOutputLogs(fileIdentifier, null, promise);
     }
 }

--- a/android/src/main/java/com/reactlibrary/RNNativeLogsModule.java
+++ b/android/src/main/java/com/reactlibrary/RNNativeLogsModule.java
@@ -44,7 +44,7 @@ public class RNNativeLogsModule extends ReactContextBaseJavaModule {
 
             if (logLevel != null) {
                 String packagePrefix = reactContext.getPackageName() + ":";
-                commandBuilder.append(" *:").append(logLevel).append(" ").append(packagePrefix).append(logLevel);
+                commandBuilder.append(" *:").append(logLevel);
             }
 
             String command = commandBuilder.toString();

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export const NativeLogs = {
 
   /** Redirects the native logs from the console to a given file.
     * @param {string} identifier - The name of the file to write the logs to.
-    * @param {LogLevel} logLevel - [ANDROID only] The log level to redirect. Can be one of: "D" for debug, "I" for info, "W" for warn, "E" for error, "F" for fatal.
+    * @param {LogLevel | undefined} logLevel - [ANDROID only] The log level to redirect. Can be one of: "D" for debug, "I" for info, "W" for warn, "E" for error, "F" for fatal.
     * @returns {Promise<void>} - A promise that resolves when the logs are redirected.
   */
   async redirectLogs(identifier: string, logLevel?: LogLevel): Promise<void> {
@@ -23,15 +23,13 @@ export const NativeLogs = {
 
   /** Gets all new logs since the last call to this function.
     * @param {string} identifier - The name of the file to read the logs to.
-    * @param {string[]} tags - [ANDROID only] An array of tags to exclude from the logs. Only logs that do not match these tags will be redirected.
+    * @param {string[] | undefined} tags - [ANDROID only] An array of tags to exclude from the logs. Only logs that do not match these tags will be redirected.
     * @returns {Promise<string[] | null>} - A promise that resolves with the new logs or null if there are no logs.
   */
   async getNewLogs(identifier: string, tags?: string[]): Promise<string[] | null> {
-    const allNativeLogs = Platform.OS === "ios" ?
+    const allNativeLogs = Platform.OS === "ios" || !tags ?
       await RNNativeLogs.readOutputLogs(identifier) :
-      (tags ?
-        await RNNativeLogs.readOutputLogs(identifier, tags) :
-        await RNNativeLogs.readOutputLogs(identifier));
+      await RNNativeLogs.readOutputLogs(identifier, tags);
 
     const arrayWithNewlogs = allNativeLogs.slice(this.currentLogsIndex[identifier] || 0);
     this.currentLogsIndex[identifier] = Math.max(0, allNativeLogs.length);
@@ -43,11 +41,13 @@ export const NativeLogs = {
 
   /** Gets all logs from the given file.
     * @param {string} identifier - The name of the file to read the logs to.
-    * @param {string[]} tags - [ANDROID only] An array of tags to exclude from the logs. Only logs that do not match these tags will be redirected.
+    * @param {string[] | undefined} tags - [ANDROID only] An array of tags to exclude from the logs. Only logs that do not match these tags will be redirected.
     * @returns {Promise<string[] | null>} - A promise that resolves with the logs or null if there are no logs.
   */
   async getLogs(identifier: string, tags?: string[]): Promise<string[] | null> {
-    const allNativeLogs = await RNNativeLogs.readOutputLogs(identifier, tags);
+    const allNativeLogs = Platform.OS === "ios" || !tags ?
+      await RNNativeLogs.readOutputLogs(identifier) :
+      await RNNativeLogs.readOutputLogs(identifier, tags);
     if (allNativeLogs.length < 1) {
       return null;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { NativeModules } from "react-native";
+import { NativeModules, Platform } from "react-native";
 
 const { RNNativeLogs } = NativeModules;
 
@@ -7,44 +7,32 @@ export const NativeLogs = {
 
   /** Redirects the native logs from the console to a given file.
     * @param {string} identifier - The name of the file to write the logs to.
+    * @param {string} logLevel - [ANDROID only] The log level to redirect. Can be one of: "D" for debug, "I" for info, "W" for warn, "E" for error, "F" for fatal.
     * @returns {Promise<void>} - A promise that resolves when the logs are redirected.
   */
-  async redirectLogs(identifier: string): Promise<void> {
+  async redirectLogs(identifier: string, logLevel?: string): Promise<void> {
     this.currentLogsIndex[identifier] = 0;
-    await RNNativeLogs.setUpRedirectLogs(identifier);
-  },
-
-  /** Redirects the native logs from the console to a given file.
-  * @param {string} identifier - The name of the file to write the logs to.
-  * @param {string} logLevel - The log level to redirect. Can be one of: "D" for debug, "I" for info, "W" for warn, "E" for error, "F" for fatal.
-  * @returns {Promise<void>} - A promise that resolves when the logs are redirected.
-  */
-  async redirectFilteredLogs(identifier: string, logLevel: string): Promise<void> {
-    this.currentLogsIndex[identifier] = 0;
-    await RNNativeLogs.setUpRedirectLogs(identifier, logLevel);
-  },
-
-  /** Gets all new logs since the last call to this function.
-    * @param {string} identifier - The name of the file to read the logs to.
-    * @returns {Promise<string[] | null>} - A promise that resolves with the new logs or null if there are no logs.
-  */
-  async getNewLogs(identifier: string): Promise<string[] | null> {
-    const allNativeLogs = await RNNativeLogs.readOutputLogs(identifier);
-    const arrayWithNewlogs = allNativeLogs.slice(this.currentLogsIndex[identifier] || 0);
-    this.currentLogsIndex[identifier] = Math.max(0, allNativeLogs.length);
-    if (arrayWithNewlogs.length < 1) {
-      return null;
+    if (Platform.OS === "ios" || !logLevel) {
+      await RNNativeLogs.setUpRedirectLogs(identifier);
+    } else {
+      await RNNativeLogs.setUpRedirectLogs(identifier, logLevel);
     }
-    return arrayWithNewlogs;
   },
 
   /** Gets all new logs since the last call to this function.
     * @param {string} identifier - The name of the file to read the logs to.
-    * @param {string[]} tags - An array of tags to exclude from the logs. Only logs that do not match these tags will be redirected.
+    * @param {string[]} tags - [ANDROID only] An array of tags to exclude from the logs. Only logs that do not match these tags will be redirected.
     * @returns {Promise<string[] | null>} - A promise that resolves with the new logs or null if there are no logs.
   */
-  async getNewFilteredLogs(identifier: string, tags: string[]): Promise<string[] | null> {
-    const allNativeLogs = await RNNativeLogs.readOutputLogs(identifier, tags);
+  async getNewLogs(identifier: string, tags?: string[]): Promise<string[] | null> {
+    let allNativeLogs: string[];
+    if (Platform.OS === "ios") {
+      allNativeLogs = await RNNativeLogs.readOutputLogs(identifier);
+    } else {
+      allNativeLogs = tags ?
+        await RNNativeLogs.readOutputLogs(identifier, tags) :
+        await RNNativeLogs.readOutputLogs(identifier);
+    }
     const arrayWithNewlogs = allNativeLogs.slice(this.currentLogsIndex[identifier] || 0);
     this.currentLogsIndex[identifier] = Math.max(0, allNativeLogs.length);
     if (arrayWithNewlogs.length < 1) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,10 +43,10 @@ export const NativeLogs = {
 
   /** Gets all logs from the given file.
     * @param {string} identifier - The name of the file to read the logs to.
-    * @param {string[]} tags - An array of tags to exclude from the logs. Only logs that do not match these tags will be redirected.
+    * @param {string[]} tags - [ANDROID only] An array of tags to exclude from the logs. Only logs that do not match these tags will be redirected.
     * @returns {Promise<string[] | null>} - A promise that resolves with the logs or null if there are no logs.
   */
-  async getLogs(identifier: string, tags: string[]): Promise<string[] | null> {
+  async getLogs(identifier: string, tags?: string[]): Promise<string[] | null> {
     const allNativeLogs = await RNNativeLogs.readOutputLogs(identifier, tags);
     if (allNativeLogs.length < 1) {
       return null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,35 @@ export const NativeLogs = {
 
   /** Redirects the native logs from the console to a given file.
     * @param {string} identifier - The name of the file to write the logs to.
-    * @param {string} logLevel - The log level to redirect. Can be one of: "D" for debug, "I" for info, "W" for warn, "E" for error, "F" for fatal.
     * @returns {Promise<void>} - A promise that resolves when the logs are redirected.
   */
-  async redirectLogs(identifier: string, logLevel: string): Promise<void> {
+  async redirectLogs(identifier: string): Promise<void> {
+    this.currentLogsIndex[identifier] = 0;
+    await RNNativeLogs.setUpRedirectLogs(identifier);
+  },
+
+  /** Redirects the native logs from the console to a given file.
+  * @param {string} identifier - The name of the file to write the logs to.
+  * @param {string} logLevel - The log level to redirect. Can be one of: "D" for debug, "I" for info, "W" for warn, "E" for error, "F" for fatal.
+  * @returns {Promise<void>} - A promise that resolves when the logs are redirected.
+  */
+  async redirectFilteredLogs(identifier: string, logLevel: string): Promise<void> {
     this.currentLogsIndex[identifier] = 0;
     await RNNativeLogs.setUpRedirectLogs(identifier, logLevel);
+  },
+
+  /** Gets all new logs since the last call to this function.
+    * @param {string} identifier - The name of the file to read the logs to.
+    * @returns {Promise<string[] | null>} - A promise that resolves with the new logs or null if there are no logs.
+  */
+  async getNewLogs(identifier: string): Promise<string[] | null> {
+    const allNativeLogs = await RNNativeLogs.readOutputLogs(identifier);
+    const arrayWithNewlogs = allNativeLogs.slice(this.currentLogsIndex[identifier] || 0);
+    this.currentLogsIndex[identifier] = Math.max(0, allNativeLogs.length);
+    if (arrayWithNewlogs.length < 1) {
+      return null;
+    }
+    return arrayWithNewlogs;
   },
 
   /** Gets all new logs since the last call to this function.
@@ -20,7 +43,7 @@ export const NativeLogs = {
     * @param {string[]} tags - An array of tags to exclude from the logs. Only logs that do not match these tags will be redirected.
     * @returns {Promise<string[] | null>} - A promise that resolves with the new logs or null if there are no logs.
   */
-  async getNewLogs(identifier: string, tags: string[]): Promise<string[] | null> {
+  async getNewFilteredLogs(identifier: string, tags: string[]): Promise<string[] | null> {
     const allNativeLogs = await RNNativeLogs.readOutputLogs(identifier, tags);
     const arrayWithNewlogs = allNativeLogs.slice(this.currentLogsIndex[identifier] || 0);
     this.currentLogsIndex[identifier] = Math.max(0, allNativeLogs.length);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,22 +4,24 @@ const { RNNativeLogs } = NativeModules;
 
 export const NativeLogs = {
   currentLogsIndex: {} as { [key: string]: number },
-  
+
   /** Redirects the native logs from the console to a given file.
     * @param {string} identifier - The name of the file to write the logs to.
+    * @param {string} logLevel - The log level to redirect. Can be one of: "D" for debug, "I" for info, "W" for warn, "E" for error, "F" for fatal.
     * @returns {Promise<void>} - A promise that resolves when the logs are redirected.
   */
-  async redirectLogs(identifier: string): Promise<void> {
+  async redirectLogs(identifier: string, logLevel: string): Promise<void> {
     this.currentLogsIndex[identifier] = 0;
-    await RNNativeLogs.setUpRedirectLogs(identifier);
+    await RNNativeLogs.setUpRedirectLogs(identifier, logLevel);
   },
 
   /** Gets all new logs since the last call to this function.
     * @param {string} identifier - The name of the file to read the logs to.
+    * @param {string[]} tags - An array of tags to exclude from the logs. Only logs that do not match these tags will be redirected.
     * @returns {Promise<string[] | null>} - A promise that resolves with the new logs or null if there are no logs.
   */
-  async getNewLogs(identifier: string): Promise<string[] | null> {
-    const allNativeLogs = await RNNativeLogs.readOutputLogs(identifier);
+  async getNewLogs(identifier: string, tags: string[]): Promise<string[] | null> {
+    const allNativeLogs = await RNNativeLogs.readOutputLogs(identifier, tags);
     const arrayWithNewlogs = allNativeLogs.slice(this.currentLogsIndex[identifier] || 0);
     this.currentLogsIndex[identifier] = Math.max(0, allNativeLogs.length);
     if (arrayWithNewlogs.length < 1) {
@@ -27,13 +29,14 @@ export const NativeLogs = {
     }
     return arrayWithNewlogs;
   },
-  
+
   /** Gets all logs from the given file.
     * @param {string} identifier - The name of the file to read the logs to.
+    * @param {string[]} tags - An array of tags to exclude from the logs. Only logs that do not match these tags will be redirected.
     * @returns {Promise<string[] | null>} - A promise that resolves with the logs or null if there are no logs.
   */
-  async getLogs(identifier: string): Promise<string[] | null> {
-    const allNativeLogs = await RNNativeLogs.readOutputLogs(identifier);
+  async getLogs(identifier: string, tags: string[]): Promise<string[] | null> {
+    const allNativeLogs = await RNNativeLogs.readOutputLogs(identifier, tags);
     if (allNativeLogs.length < 1) {
       return null;
     }


### PR DESCRIPTION
# Description

This pull request adds filtering functionality to the Android native logs. The changes include the addition of a new `isIgnoredTag` method and an updated version of `readOutputLogs` that takes a `tags` parameter to filter out log lines that contain any of the specified tags.

In addition, the `setUpRedirectLogs` method also was updated and it can now receive an optional string parameter that specifies the log priority level.

### Changes Made

- Added `isIgnoredTag` method to check if a log line should be ignored based on the specified tags
- Updated `readOutputLogs` to take a `tags` parameter and filter out log lines that contain any of the specified tags
- Updated `setUpRedirectLogs` method to receive an optional log priority level parameter

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Result

With these changes, the Android native logs module now provides a more customizable logging experience, allowing developers to filter specific log tags and set log priority levels as needed.